### PR TITLE
Use cert directory from acme module

### DIFF
--- a/ldap-server.nix
+++ b/ldap-server.nix
@@ -101,7 +101,7 @@ in {
     '';
 
     systemd.services.portunus = let
-      acmeDirectory = "/var/lib/acme/${cfg.ldapDomainName}";
+      acmeDirectory = config.security.acme.certs.${cfg.ldapDomainName}.directory;
     in {
       environment = {
         PORTUNUS_SLAPD_TLS_CA_CERTIFICATE = "${acmeDirectory}/complete-chain.pem";


### PR DESCRIPTION
see https://search.nixos.org/options?channel=unstable&show=security.acme.certs.%3Cname%3E.directory&from=0&size=50&sort=relevance&type=packages&query=security.acme.certs.%3Cname%3E.directory

Please check if this evals and does not cause an infinite recursion which it shouldn't.