### PR TITLE
Use one byte shorter rsa keys

### DIFF
--- a/gitea.nix
+++ b/gitea.nix
@@ -54,7 +54,7 @@ in {
           DSA = -1;
           ECDSA = -1;
           ED25519 = 256;
-          RSA = 4096;
+          RSA = 4095;
         };
 
         "service" = {


### PR DESCRIPTION
If a key starts with 0, it is counted as one byte shorter https://github.com/go-gitea/gitea/issues/20249